### PR TITLE
[Ezy Login] : Layout bounds enable/disable action added.

### DIFF
--- a/src/main/kotlin/com/darshan/ezylogin/action/DisableLayoutBoundsAction.kt
+++ b/src/main/kotlin/com/darshan/ezylogin/action/DisableLayoutBoundsAction.kt
@@ -1,0 +1,9 @@
+package com.darshan.ezylogin.action
+
+import com.darshan.ezylogin.adb.AdbFacade
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
+
+class DisableLayoutBoundsAction : AdbAction() {
+    override fun actionPerformed(e: AnActionEvent, project: Project) = AdbFacade.DisableLayoutBoundsAction(project)
+}

--- a/src/main/kotlin/com/darshan/ezylogin/action/EnableLayoutBoundsAction.kt
+++ b/src/main/kotlin/com/darshan/ezylogin/action/EnableLayoutBoundsAction.kt
@@ -1,0 +1,9 @@
+package com.darshan.ezylogin.action
+
+import com.darshan.ezylogin.adb.AdbFacade
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
+
+class EnableLayoutBoundsAction : AdbAction() {
+    override fun actionPerformed(e: AnActionEvent, project: Project) = AdbFacade.EnableLayoutBoundsAction(project)
+}

--- a/src/main/kotlin/com/darshan/ezylogin/action/QuickListAction.kt
+++ b/src/main/kotlin/com/darshan/ezylogin/action/QuickListAction.kt
@@ -20,6 +20,8 @@ class QuickListAction : QuickSwitchSchemeAction(), DumbAware {
         addAction("com.darshan.ezylogin.action.ClearDataAction", group)
         addAction("com.darshan.ezylogin.action.ClearDataAndRestartAction", group)
         addAction("com.darshan.ezylogin.action.EzyLoginAction", group)
+        addAction("com.darshan.ezylogin.action.EnableLayoutBoundsAction", group)
+        addAction("com.darshan.ezylogin.action.DisableLayoutBoundsAction", group)
         if (LoginComponent.getInstance().state?.previouslyLoggedInIndex != -1) {
             addAction("com.darshan.ezylogin.action.EzyLoginToPreviouslyLoggedInAccountAction", group)
         }

--- a/src/main/kotlin/com/darshan/ezylogin/adb/AdbFacade.kt
+++ b/src/main/kotlin/com/darshan/ezylogin/adb/AdbFacade.kt
@@ -21,6 +21,8 @@ object AdbFacade {
     fun disableMobile(project: Project) = executeOnDevice(project, ToggleSvcCommand(MOBILE, false))
     fun EzyLogin(project: Project) = executeOnDevice(project, EzyLoginCommand())
     fun EzyLoginToPreviousAccount(project: Project) = executeOnDevice(project, EzyLoginToPreviousAccountCommand())
+    fun EnableLayoutBoundsAction(project: Project) = executeOnDevice(project, EnableLayoutBoundsActionCommand())
+    fun DisableLayoutBoundsAction(project: Project) = executeOnDevice(project, DisableLayoutBoundsActionCommand())
 
     private fun executeOnDevice(project: Project, runnable: Command) {
         if (AdbUtil.isGradleSyncInProgress(project)) {

--- a/src/main/kotlin/com/darshan/ezylogin/adb/command/DisableLayoutBoundsActionCommand.kt
+++ b/src/main/kotlin/com/darshan/ezylogin/adb/command/DisableLayoutBoundsActionCommand.kt
@@ -1,0 +1,22 @@
+package com.darshan.ezylogin.adb.command
+
+import com.android.ddmlib.IDevice
+import com.darshan.ezylogin.adb.command.receiver.GenericReceiver
+import com.darshan.ezylogin.ui.NotificationHelper
+import com.intellij.openapi.project.Project
+import org.jetbrains.android.facet.AndroidFacet
+import java.util.concurrent.TimeUnit
+
+class DisableLayoutBoundsActionCommand : Command {
+    override fun run(project: Project, device: IDevice, facet: AndroidFacet, packageName: String): Boolean {
+
+        try {
+            device.executeShellCommand("setprop debug.layout false ; service call activity 1599295570", GenericReceiver(), 10L, TimeUnit.SECONDS)
+            NotificationHelper.info(String.format("<b>%s</b> Layout bounds disabled on %s", packageName, device.name))
+            return true
+        } catch (e1: Exception) {
+            NotificationHelper.error("Layout bound disable failed... " + e1.message)
+        }
+        return false
+    }
+}

--- a/src/main/kotlin/com/darshan/ezylogin/adb/command/EnableLayoutBoundsActionCommand.kt
+++ b/src/main/kotlin/com/darshan/ezylogin/adb/command/EnableLayoutBoundsActionCommand.kt
@@ -1,0 +1,22 @@
+package com.darshan.ezylogin.adb.command
+
+import com.android.ddmlib.IDevice
+import com.darshan.ezylogin.adb.command.receiver.GenericReceiver
+import com.darshan.ezylogin.ui.NotificationHelper
+import com.intellij.openapi.project.Project
+import org.jetbrains.android.facet.AndroidFacet
+import java.util.concurrent.TimeUnit
+
+class EnableLayoutBoundsActionCommand : Command {
+    override fun run(project: Project, device: IDevice, facet: AndroidFacet, packageName: String): Boolean {
+
+        try {
+            device.executeShellCommand("setprop debug.layout true ; service call activity 1599295570", GenericReceiver(), 10L, TimeUnit.SECONDS)
+            NotificationHelper.info(String.format("<b>%s</b> Layout bounds enabled on %s", packageName, device.name))
+            return true
+        } catch (e1: Exception) {
+            NotificationHelper.error("Layout bounds enable failed... " + e1.message)
+        }
+        return false
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -106,6 +106,16 @@
                     text="Login To Previously Used Account"
                     description="Login to previously used account">
             </action>
+
+            <action id="com.darshan.ezylogin.action.EnableLayoutBoundsAction"
+                    class="com.darshan.ezylogin.action.EnableLayoutBoundsAction"
+                    text="Enable Layout Bounds"
+                    description="Enable layout bounds"/>
+
+            <action id="com.darshan.ezylogin.action.DisableLayoutBoundsAction"
+                    class="com.darshan.ezylogin.action.DisableLayoutBoundsAction"
+                    text="Disable Layout Bounds"
+                    description="Disable layout bounds"/>
         </group>
     </actions>
 


### PR DESCRIPTION
### Description - A short description of the feature and why it is needed
PR for the implementation of the Layout enabling and Disabling feature for the plugin which makes enabling and disabling of the Layout bounds much easier rather than manually doing it from the device's settings option every time.
We can enable/disable Layout bounds by going to **_Tools->Ezylogin->Enable Layout bounds/Disable layout bounds_** or,
by using the 'Ctrl + Shift + A' for the popup menu with the features.

### Screenshots - Demonstrate what changes there are
Layout bounds enabled

<img width="1384" alt="Screenshot 2021-03-19 at 6 34 15 PM" src="https://user-images.githubusercontent.com/71811504/111784887-ec651a00-88e1-11eb-85e9-98c6e40e8a93.png">

Layout bounds disabled

<img width="1395" alt="Screenshot 2021-03-19 at 6 35 20 PM" src="https://user-images.githubusercontent.com/71811504/111784969-07378e80-88e2-11eb-93fa-6a4ed8db66be.png">



